### PR TITLE
Implement standalone G-code generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,29 @@
 cmake_minimum_required(VERSION 3.10)
 project(TractobotsPlannerQt)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
-find_package(Boost REQUIRED COMPONENTS geometry)
+set(CMAKE_CXX_STANDARD 17)
 
-add_executable(tracto_planner_qt
-  src/main.cpp
-  src/MainWindow.cpp
-  src/PathPlanner.cpp
-  src/MainWindow.h
-  src/PathPlanner.h
-  src/Ui_MainWindow.ui
-)
+option(BUILD_GUI "Build Qt GUI" OFF)
+enable_testing()
+if(BUILD_GUI)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets)
+  find_package(Boost REQUIRED COMPONENTS geometry)
 
-qt6_wrap_ui(UISrcs src/Ui_MainWindow.ui)
+  add_executable(tracto_planner_qt
+    Scr/main.cpp
+    Scr/MainWindow.cpp
+    Scr/PathPlanner.cpp
+    Scr/MainWindow.h
+    Scr/PathPlanner.h
+    Scr/Ui_MainWindow.ui
+  )
 
-target_link_libraries(tracto_planner_qt
-  Qt6::Widgets
-  Boost::geometry
-)
+  qt6_wrap_ui(UISrcs Scr/Ui_MainWindow.ui)
+
+  target_link_libraries(tracto_planner_qt
+    Qt6::Widgets
+    Boost::geometry
+  )
+endif()
+
+add_subdirectory(src/gcode_gen)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ cmake --build . --parallel
 
 # 5. Run
 ./tracto_planner_qt
+
+```
+
+To build the command-line G-code generator:
+
+```bash
+# Build once
+cmake -S . -B build && cmake --build build -j
+
+# Generate map
+./build/gcode_gen \
+    --in waypoints.csv \
+    --out north_strip.gcode \
+    --comment "North paddock – May 2025" \
+    --speed 0.9
 ```
 
 ---

--- a/src/gcode_gen/CMakeLists.txt
+++ b/src/gcode_gen/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(gcode_utils
+  src/waypoint_io.cpp
+  src/converter.cpp)
+target_include_directories(gcode_utils PUBLIC include)
+
+add_executable(gcode_gen src/main.cpp)
+target_link_libraries(gcode_gen PRIVATE gcode_utils)
+
+enable_testing()
+add_executable(gcode_gen_tests tests/test_converter.cpp)
+target_link_libraries(gcode_gen_tests PRIVATE gcode_utils)
+add_test(NAME gcode_gen_tests COMMAND gcode_gen_tests)

--- a/src/gcode_gen/include/gcode_gen/converter.hpp
+++ b/src/gcode_gen/include/gcode_gen/converter.hpp
@@ -1,0 +1,21 @@
+#ifndef GCODE_GEN_CONVERTER_HPP
+#define GCODE_GEN_CONVERTER_HPP
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "gcode_gen/waypoint.hpp"
+
+namespace gcode_gen {
+
+std::vector<std::string> toGcode(const std::vector<Waypoint>& wps,
+                                 bool relative,
+                                 int downCode,
+                                 int upCode,
+                                 double speed,
+                                 std::string_view comment);
+
+} // namespace gcode_gen
+
+#endif // GCODE_GEN_CONVERTER_HPP

--- a/src/gcode_gen/include/gcode_gen/waypoint.hpp
+++ b/src/gcode_gen/include/gcode_gen/waypoint.hpp
@@ -1,0 +1,20 @@
+#ifndef GCODE_GEN_WAYPOINT_HPP
+#define GCODE_GEN_WAYPOINT_HPP
+#include <string>
+#include <vector>
+
+namespace gcode_gen {
+
+struct Waypoint {
+    double lat{0};
+    double lon{0};
+    double alt{0};
+    bool tool_down{false};
+    bool has_tool{false};
+};
+
+std::vector<Waypoint> readWaypoints(const std::string& path, const std::string& z_field = "alt");
+
+} // namespace gcode_gen
+
+#endif // GCODE_GEN_WAYPOINT_HPP

--- a/src/gcode_gen/src/converter.cpp
+++ b/src/gcode_gen/src/converter.cpp
@@ -1,0 +1,70 @@
+#include "gcode_gen/converter.hpp"
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+namespace gcode_gen {
+
+static constexpr double kDegToRad = M_PI / 180.0;
+static constexpr double kEarthR = 6371000.0; // metres
+
+std::vector<std::string> toGcode(const std::vector<Waypoint>& wp_in,
+                                 bool relative,
+                                 int downCode,
+                                 int upCode,
+                                 double speed,
+                                 std::string_view comment) {
+    if (wp_in.empty()) return {};
+
+    // copy while removing consecutive duplicates
+    std::vector<Waypoint> wps;
+    wps.reserve(wp_in.size());
+    Waypoint last{9999,9999,0,false};
+    for (const auto& w : wp_in) {
+        if (w.lat==last.lat && w.lon==last.lon && w.alt==last.alt && w.tool_down==last.tool_down) continue;
+        wps.push_back(w);
+        last = w;
+    }
+
+    std::vector<std::string> lines;
+    if (!comment.empty())
+        lines.push_back(std::string("; ")+std::string(comment));
+    lines.push_back(relative ? "G91" : "G90");
+
+    bool any_tool = false;
+    for (const auto& w : wps) if (w.has_tool) { any_tool = true; break; }
+    bool tool_state = false;
+    Waypoint prev = wps.front();
+    (void)prev; // silence unused if only one
+    for (size_t i=0;i<wps.size();++i) {
+        const auto& wp = wps[i];
+        if (any_tool) {
+            if (i==0) {
+                tool_state = wp.tool_down;
+                lines.push_back(std::string("M") + std::to_string(tool_state ? downCode : upCode));
+            } else if (wp.tool_down != tool_state) {
+                tool_state = wp.tool_down;
+                lines.push_back(std::string("M") + std::to_string(tool_state ? downCode : upCode));
+            }
+        }
+        std::ostringstream ss;
+        ss.setf(std::ios::fixed); ss.precision(6);
+        ss << "G1 ";
+        if (relative) {
+            const auto& prev_wp = (i==0?wps[0]:wps[i-1]);
+            double dx = (wp.lon - prev_wp.lon) * std::cos((wp.lat+prev_wp.lat)/2*kDegToRad) * kDegToRad * kEarthR;
+            double dy = (wp.lat - prev_wp.lat) * kDegToRad * kEarthR;
+            ss << "X" << dx << " Y" << dy;
+        } else {
+            ss << "X" << wp.lat << " Y" << wp.lon;
+        }
+        if (i==0) {
+            ss << " F" << speed;
+        }
+        lines.push_back(ss.str());
+    }
+    return lines;
+}
+
+} // namespace gcode_gen

--- a/src/gcode_gen/src/main.cpp
+++ b/src/gcode_gen/src/main.cpp
@@ -1,0 +1,58 @@
+#include "gcode_gen/converter.hpp"
+#include "gcode_gen/waypoint.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace gcode_gen;
+
+int main(int argc, char** argv) {
+    std::string in_path;
+    std::string out_path;
+    bool relative = false;
+    int down_code = 100;
+    int up_code = 101;
+    double speed = 1.0;
+    std::string comment;
+    std::string z_field = "alt";
+
+    for (int i=1;i<argc;i++) {
+        std::string arg = argv[i];
+        auto get_val = [&](const std::string& name)->std::string {
+            if (i+1 >= argc) throw std::runtime_error("Missing value for " + name);
+            return argv[++i];
+        };
+        if (arg == "--in") in_path = get_val("--in");
+        else if (arg == "--out") out_path = get_val("--out");
+        else if (arg == "--relative") relative = true;
+        else if (arg == "--down-code") down_code = std::stoi(get_val(arg));
+        else if (arg == "--up-code") up_code = std::stoi(get_val(arg));
+        else if (arg == "--speed") speed = std::stod(get_val(arg));
+        else if (arg == "--comment") comment = get_val(arg);
+        else if (arg == "--z-field") z_field = get_val(arg);
+        else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            return 1;
+        }
+    }
+
+    if (in_path.empty() || out_path.empty()) {
+        std::cerr << "--in and --out required\n";
+        return 1;
+    }
+
+    auto wps = readWaypoints(in_path, z_field);
+    if (wps.size() > 10000) {
+        std::cerr << "Warning: large waypoint count: " << wps.size() << "\n";
+    }
+    auto lines = toGcode(wps, relative, down_code, up_code, speed, comment);
+
+    std::ofstream out(out_path);
+    if (!out.is_open()) {
+        std::cerr << "Failed to open output: " << out_path << "\n";
+        return 1;
+    }
+    for (const auto& l : lines) out << l << "\n";
+    return 0;
+}

--- a/src/gcode_gen/src/waypoint_io.cpp
+++ b/src/gcode_gen/src/waypoint_io.cpp
@@ -1,0 +1,119 @@
+#include "gcode_gen/waypoint.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <cctype>
+
+namespace gcode_gen {
+namespace {
+
+static bool startsWith(const std::string& s, char c) {
+    for (char ch : s) {
+        if (!std::isspace(static_cast<unsigned char>(ch)))
+            return ch == c;
+    }
+    return false;
+}
+
+static std::vector<std::string> split(const std::string& line, char delim) {
+    std::vector<std::string> out;
+    std::string cur;
+    std::istringstream ss(line);
+    while (std::getline(ss, cur, delim)) {
+        out.push_back(cur);
+    }
+    return out;
+}
+
+static bool parseBool(const std::string& s) {
+    return s == "1" || s == "true" || s == "True";
+}
+
+} // namespace
+
+std::vector<Waypoint> readWaypoints(const std::string& path, const std::string& z_field) {
+    std::ifstream in(path);
+    if (!in.is_open())
+        throw std::runtime_error("Failed to open waypoint file: " + path);
+
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+
+    std::vector<Waypoint> waypoints;
+
+    if (startsWith(contents, '[')) {
+        // very small JSON parser for expected format
+        size_t pos = 0;
+        while (true) {
+            pos = contents.find('{', pos);
+            if (pos == std::string::npos) break;
+            size_t end = contents.find('}', pos);
+            if (end == std::string::npos) break;
+            std::string obj = contents.substr(pos + 1, end - pos - 1);
+            pos = end + 1;
+            Waypoint wp;
+            std::istringstream os(obj);
+            std::string kv;
+            while (std::getline(os, kv, ',')) {
+                auto colon = kv.find(':');
+                if (colon == std::string::npos) continue;
+                std::string key = kv.substr(0, colon);
+                std::string value = kv.substr(colon + 1);
+                // trim spaces and quotes
+                auto trim = [](std::string s) {
+                    size_t b = 0;
+                    while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b]))) ++b;
+                    size_t e = s.size();
+                    while (e > b && std::isspace(static_cast<unsigned char>(s[e-1]))) --e;
+                    if (e > b && s[b] == '"') ++b;
+                    if (e > b && s[e-1] == '"') --e;
+                    return s.substr(b, e-b);
+                };
+                key = trim(key);
+                value = trim(value);
+                if (key == "lat") wp.lat = std::stod(value);
+                else if (key == "lon") wp.lon = std::stod(value);
+                else if (key == z_field) wp.alt = std::stod(value);
+                else if (key == "tool") { wp.tool_down = parseBool(value); wp.has_tool = true; }
+            }
+            waypoints.push_back(wp);
+        }
+    } else {
+        // CSV or TSV
+        std::istringstream ss(contents);
+        std::string header;
+        if (!std::getline(ss, header))
+            return waypoints;
+        char delim = header.find('\t') != std::string::npos ? '\t' : ',';
+        auto cols = split(header, delim);
+        int lat_idx=-1, lon_idx=-1, alt_idx=-1, tool_idx=-1;
+        for (size_t i=0;i<cols.size();++i) {
+            if (cols[i]=="lat") lat_idx=i;
+            else if (cols[i]=="lon") lon_idx=i;
+            else if (cols[i]==z_field) alt_idx=i;
+            else if (cols[i]=="tool") tool_idx=i;
+        }
+        if (lat_idx<0 || lon_idx<0)
+            throw std::runtime_error("lat/lon columns required");
+        std::string line;
+        while (std::getline(ss, line)) {
+            if (line.empty()) continue;
+            auto vals = split(line, delim);
+            if ((int)vals.size() <= std::max({lat_idx, lon_idx, alt_idx, tool_idx})) continue;
+            Waypoint wp;
+            wp.lat = std::stod(vals[lat_idx]);
+            wp.lon = std::stod(vals[lon_idx]);
+            if (alt_idx>=0) wp.alt = std::stod(vals[alt_idx]);
+            if (tool_idx>=0) { wp.tool_down = parseBool(vals[tool_idx]); wp.has_tool = true; }
+            waypoints.push_back(wp);
+        }
+    }
+
+    return waypoints;
+}
+
+} // namespace gcode_gen

--- a/src/gcode_gen/tests/test_converter.cpp
+++ b/src/gcode_gen/tests/test_converter.cpp
@@ -1,0 +1,29 @@
+#include "gcode_gen/converter.hpp"
+#include "gcode_gen/waypoint.hpp"
+
+#include <cassert>
+#include <fstream>
+#include <vector>
+
+using namespace gcode_gen;
+
+int main() {
+    const char* data = "[{'lat':35.6896,'lon':-120.6915},{'lat':35.6897,'lon':-120.6916},{'lat':35.6898,'lon':-120.6917}]";
+    std::ofstream f("test.json");
+    std::string s(data);
+    for (char& c : s) if (c=='\'') c='"';
+    f << s;
+    f.close();
+
+    auto wps = readWaypoints("test.json", "alt");
+    auto lines = toGcode(wps, false, 100, 101, 1.0, "demo");
+    assert(!lines.empty());
+    assert(lines[0].rfind(";",0)==0);
+    assert(lines.size()>=3);
+    assert(lines[2]=="G1 X35.689600 Y-120.691500 F1" || lines[2]=="G1 X35.689600 Y-120.691500" || lines[2].rfind("G1 X35.689600 Y-120.691500",0)==0);
+
+    auto rel = toGcode(wps, true, 100, 101, 1.0, "demo");
+    assert(rel.size()>=3);
+    assert(rel[1]=="G91");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add new `gcode_gen` utility written in C++17
- provide waypoint reader and converter
- include simple unit test
- update build system with optional GUI and enable testing
- document new command-line workflow in README

## Testing
- `cmake -DBUILD_GUI=OFF ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `./src/gcode_gen/gcode_gen --in demo.json --out demo.gcode --comment demo`

------
https://chatgpt.com/codex/tasks/task_e_683bb35712388321a1346a6c7bc27266