### PR TITLE
Enable CI workflow for build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Build & Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF
+    - name: Build
+      run: cmake --build build --config Release
+    - name: Test
+      run: ctest --test-dir build --output-on-failure -C Release


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and run tests on push and PR

## Testing
- `cmake -S . -B build -DBUILD_GUI=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683bbc3884608321b36b91443bcaa6cf