### PR TITLE
Fix Windows M_PI build error

### DIFF
--- a/src/gcode_gen/src/converter.cpp
+++ b/src/gcode_gen/src/converter.cpp
@@ -1,5 +1,8 @@
 #include "gcode_gen/converter.hpp"
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
## Summary
- enable `_USE_MATH_DEFINES` before including `<cmath>`

## Testing
- `cmake -S .. -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bbf5e8a788321b83acf11370b308a