### PR TITLE
Fix Windows build by defining M_PI

### DIFF
--- a/src/gcode_gen/src/converter.cpp
+++ b/src/gcode_gen/src/converter.cpp
@@ -4,6 +4,10 @@
 #define _USE_MATH_DEFINES
 #endif
 #include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <sstream>
 #include <stdexcept>
 


### PR DESCRIPTION
## Summary
- define `M_PI` constant in `converter.cpp` to avoid build failure on MSVC

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683bc067ebac8321a32daa37c001cb91