### PR TITLE
Fix release workflow MSI output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build --config Release
 
+    # Ensure output directory exists for the installer
+    - name: Prepare dist folder
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path dist -Force | Out-Null
+
     # 3. Install WiX v4 CLI (candle/light combined into `wix.exe build`)
     - name: Install WiX Toolset
       shell: pwsh


### PR DESCRIPTION
## Summary
- ensure `dist` folder exists before packaging in release workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build -C Release --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683bc0b1eb3c8321a2f1da2c69248c07