### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Build & Release (Windows MSI)
 
 on:
   push:
+    branches: ["main"]
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   msi:


### PR DESCRIPTION
## Summary
- trigger release workflow on push to main branches and manual dispatch

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bc1e1e9c48321a35980f723c84f8d