### PR TITLE
Fix WiX directory structure

### DIFF
--- a/wix/installer.wxs
+++ b/wix/installer.wxs
@@ -6,15 +6,15 @@
            InstallerVersion="600"
            UpgradeCode="{bed5a804-5004-4e97-9dc1-c3c65803ea45}">
 
-    <!-- Install to C:\Program Files\CropCrusaders\gcode_gen -->
-    <DirectoryRef Id="ProgramFilesFolder">
-      <Directory Id="INSTALLFOLDER" Name="CropCrusaders">
-        <Directory Id="TARGETDIR" Name="gcode_gen" />
-      </Directory>
-    </DirectoryRef>
+  <!-- Install to C:\Program Files\CropCrusaders\gcode_gen -->
+  <StandardDirectory Id="ProgramFilesFolder">
+    <Directory Id="INSTALLFOLDER" Name="CropCrusaders">
+      <Directory Id="PRODUCTDIR" Name="gcode_gen" />
+    </Directory>
+  </StandardDirectory>
 
     <!-- Actual payload -->
-    <ComponentGroup Id="MainFiles" Directory="TARGETDIR">
+  <ComponentGroup Id="MainFiles" Directory="PRODUCTDIR">
       <Component>
         <File Source="build\\Release\\gcode_gen.exe" />
       </Component>


### PR DESCRIPTION
## Summary
- fix installer build error by switching to `StandardDirectory`
- rename root directory id from `TARGETDIR` to `PRODUCTDIR`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`

------
https://chatgpt.com/codex/tasks/task_e_683bc5db5c7c8321831e19e46ccab033