### PR TITLE
Fix installer path for gcode_gen

### DIFF
--- a/wix/installer.wxs
+++ b/wix/installer.wxs
@@ -16,7 +16,8 @@
     <!-- Actual payload -->
   <ComponentGroup Id="MainFiles" Directory="PRODUCTDIR">
       <Component>
-        <File Source="build\\Release\\gcode_gen.exe" />
+        <!-- Path to the executable built by CMake -->
+        <File Source="build/src/gcode_gen/Release/gcode_gen.exe" />
       </Component>
     </ComponentGroup>
 


### PR DESCRIPTION
## Summary
- adjust path to gcode_gen.exe in WiX script so the release workflow can build the MSI

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bc78203f48321bfe8d993cfb3af66