### PR TITLE
Fix release action to only run on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   msi:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
## Summary
- update release job to skip when not triggered by a tag

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bcb84ef208321bff6d3b3c06a7b49