### PR TITLE
Fix release workflow tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Build & Release (Windows MSI)
 
 on:
   push:
-    branches: ["main"]
     tags: ["v*"]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- fix trigger in `release.yml` so pushing a tag runs the workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`

------
https://chatgpt.com/codex/tasks/task_e_683bcef04f4083218d3a84d6d988c521