### PR TITLE
Fix release workflow tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,13 @@ name: Build & Release (Windows MSI)
 on:
   push:
     branches: ["main"]
-    tags: ["v*"]
+    tags: ["*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version when run manually"
+        required: true
+        default: "1"
 
 permissions:
   contents: write
@@ -12,6 +17,8 @@ permissions:
 jobs:
   msi:
     runs-on: windows-latest
+    env:
+      RELEASE_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || inputs.version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -44,19 +51,19 @@ jobs:
       run: |
         wix build wix/installer.wxs `
                  -arch x64 `
-                 -o dist/gcode_gen-${{ github.ref_name }}-x64.msi
+                 -o dist/gcode_gen-${{ env.RELEASE_VERSION }}-x64.msi
 
     # 5. Create or update the GitHub Release
     - name: Create Release
       id: release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.ref_name }}
-        name: ${{ github.ref_name }}
+        tag_name: ${{ env.RELEASE_VERSION }}
+        name: ${{ env.RELEASE_VERSION }}
         generate_release_notes: true
 
     # 6. Upload the MSI asset
     - name: Upload MSI
       uses: softprops/action-gh-release@v2
       with:
-        files: dist/gcode_gen-${{ github.ref_name }}-x64.msi
+        files: dist/gcode_gen-${{ env.RELEASE_VERSION }}-x64.msi


### PR DESCRIPTION
## Summary
- allow the release workflow to run on any tag

## Testing
- `cmake -S . -B build -DBUILD_GUI=OFF`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_683bd184f1a88321a5689ab9c01455bd