### PR TITLE
Set timezone to Brisbane in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,20 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      TZ: Australia/Brisbane
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
+    - name: Set timezone (Linux)
+      if: runner.os == 'Linux'
+      run: sudo timedatectl set-timezone 'Australia/Brisbane'
+    - name: Set timezone (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Set-TimeZone -Id 'AUS Eastern Standard Time'
     - name: Configure
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ permissions:
 jobs:
   msi:
     runs-on: windows-latest
+    env:
+      TZ: Australia/Brisbane
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set timezone
+      shell: pwsh
+      run: Set-TimeZone -Id 'AUS Eastern Standard Time'
 
     # 1. Set up MSBuild / VS toolchain
     - uses: microsoft/setup-msbuild@v1.1


### PR DESCRIPTION
## Summary
- default timezone to Brisbane in the CI workflow
- use the same timezone in the release workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bd2d2bb3c832195b91de32a1c2375