### PR TITLE
Fix workflow on key parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Build & Test
 
-on:
+'on':
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Build & Release (Windows MSI)
 
-on:
+'on':
   push:
     branches: ["main"]
     tags: ["v*"]


### PR DESCRIPTION
## Summary
- quote `on` key in CI and release workflows

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bd56ec91483219292f133352e45cb