### PR TITLE
Fix yaml key for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Build & Test
 
-on:
+"on":
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Build & Release (Windows MSI)
 
-on:
+"on":
   push:
     branches: ["main"]
     tags: ["v*"]


### PR DESCRIPTION
## Summary
- fix YAML parsing error by quoting `on` keys

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bd77275688321a9ddc5722c140fc0