### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   msi:
+    # Only run when triggered by a tag or manually
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
## Summary
- ensure GitHub release workflow runs only when triggered by a tag or manually

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bd9ad9264832190d5f3d14118aa5f