### PR TITLE
Fix dist folder removal in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,12 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build --config Release
 
+    # Remove any old installer artifacts if present
+    - name: Clean dist folder
+      shell: pwsh
+      run: |
+        if (Test-Path dist) { Remove-Item -Recurse -Force dist }
+
     # Ensure output directory exists for the installer
     - name: Prepare dist folder
       shell: pwsh


### PR DESCRIPTION
## Summary
- add a clean step to delete `dist` only when it exists

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683bddee865083219af633e542804fec