### PR TITLE
Update installer version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
       run: |
         New-Item -ItemType Directory -Path dist -Force | Out-Null
 
+    - name: Set product version
+      shell: pwsh
+      run: |
+        $ver = $env:GITHUB_REF_NAME.TrimStart('v')
+        "PRODUCT_VERSION=$ver" >> $env:GITHUB_ENV
+
     # 3. Install WiX v4 CLI (candle/light combined into `wix.exe build`)
     - name: Install WiX Toolset
       shell: pwsh
@@ -44,6 +50,7 @@ jobs:
       run: |
         wix build wix/installer.wxs `
                  -arch x64 `
+                 -dProductVersion=$env:PRODUCT_VERSION `
                  -o dist/gcode_gen-${{ github.ref_name }}-x64.msi
 
     # 5. Create or update the GitHub Release

--- a/wix/installer.wxs
+++ b/wix/installer.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="gcode_gen"
            Manufacturer="CropCrusaders"
-           Version="1.0.0"
+           Version="$(var.ProductVersion)"
            InstallerVersion="600"
            UpgradeCode="{bed5a804-5004-4e97-9dc1-c3c65803ea45}">
 


### PR DESCRIPTION
## Summary
- use Wix variable `ProductVersion` instead of hard-coded value
- expose tag version to Wix build in release workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_683be243d4b4832185ce72e2fda94b67